### PR TITLE
Disable discoverability of endpoint

### DIFF
--- a/assembly/etc/che-plugin.yaml
+++ b/assembly/etc/che-plugin.yaml
@@ -5,6 +5,7 @@ endpoints:
     attributes:
       protocol: ws
       type: terminal
+      discoverable: false
 containers:
  - name: che-machine-exec
    image: eclipse/che-machine-exec


### PR DESCRIPTION
Disable discoverability of exec endpoint which is not used at the moment and prevents starting several workspaces in the same k8s namespace.

Video that shows that exec works with this change https://www.youtube.com/watch?v=TFrQzmMHIL0