### PR TITLE
Don't fail che-machine-exec container in case unsupported infra

### DIFF
--- a/exec/exec-manager-provider.go
+++ b/exec/exec-manager-provider.go
@@ -77,7 +77,7 @@ func CreateExecManager() ExecManager {
 
 		return docker_infra.New(dockerClient, containerFilter, shellDetector)
 	default:
-		log.Fatal("Unable to create manager for current infrastructure.")
+		log.Println("Error: Unable to create manager for current infrastructure.")
 	}
 
 	return nil


### PR DESCRIPTION
### Related issue:
https://github.com/eclipse/che-machine-exec/issues/14

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>