### PR TITLE
Use hash commit to tag che-machine-exec image.

### DIFF
--- a/assembly/etc/che-plugin.yaml
+++ b/assembly/etc/che-plugin.yaml
@@ -8,7 +8,7 @@ endpoints:
       discoverable: false
 containers:
  - name: che-machine-exec
-   image: eclipse/che-machine-exec:latest
+   image: eclipse/che-machine-exec
    ports:
      - exposedPort: 4444
 editors:

--- a/assembly/etc/che-plugin.yaml
+++ b/assembly/etc/che-plugin.yaml
@@ -8,7 +8,7 @@ endpoints:
       discoverable: false
 containers:
  - name: che-machine-exec
-   image: eclipse/che-machine-exec
+   image: aandrienko/che-machine-exec:latest
    ports:
      - exposedPort: 4444
 editors:

--- a/assembly/etc/che-plugin.yaml
+++ b/assembly/etc/che-plugin.yaml
@@ -8,7 +8,7 @@ endpoints:
       discoverable: false
 containers:
  - name: che-machine-exec
-   image: aandrienko/che-machine-exec:latest
+   image: eclipse/che-machine-exec:latest
    ports:
      - exposedPort: 4444
 editors:

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ printf "${BLUE}Building service (docker image)${NC}\n"
 
 docker build --no-cache -t eclipse/che-machine-exec:latest .
 GIT_HASH=$(git rev-parse --short=7 HEAD)
-docker tag eclipse/che-machine-exec:latest aandrienko/che-machine-exec:${GIT_HASH}
+docker tag eclipse/che-machine-exec:latest eclipse/che-machine-exec:${GIT_HASH}
 
 printf "${BLUE}Generating Che plug-in file...${NC}\n"
 cd ${DIR}/assembly && ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,10 @@ NC='\033[0m'
 DIR=$(cd "$(dirname "$0")"; pwd)
 
 printf "${BLUE}Building service (docker image)${NC}\n"
-docker build -t eclipse/che-machine-exec .
+
+docker build --no-cache -t eclipse/che-machine-exec:latest .
+GIT_HASH=$(git rev-parse --short=7 HEAD)
+docker tag eclipse/che-machine-exec:latest aandrienko/che-machine-exec:${GIT_HASH}
 
 printf "${BLUE}Generating Che plug-in file...${NC}\n"
 cd ${DIR}/assembly && ./build.sh


### PR DESCRIPTION
### Referenced issue:
Needed for https://github.com/eclipse/che/issues/12780.
Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>