### PR TITLE
Add absent /tmp folder in the exec image to fix task SIGINT termination

### DIFF
--- a/dockerfiles/ci/Dockerfile
+++ b/dockerfiles/ci/Dockerfile
@@ -18,9 +18,14 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o che-machine-exec .
 RUN apk add --no-cache ca-certificates
 
-RUN adduser -D -g '' unprivilegeduser
+RUN adduser -D -g '' unprivilegeduser && \
+    mkdir -p /rootfs/tmp && chmod 1777 /rootfs/tmp
 
 FROM scratch
+
+# In the scratch you can't use Dockerfile#RUN, because there is no shell and no standard commands (mkdir and so on).
+# Add absent in the scratch /tmp folder.
+COPY --from=builder /rootfs /
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /go/src/github.com/eclipse/che-machine-exec/che-machine-exec /go/bin/che-machine-exec


### PR DESCRIPTION
## Referenced issue: 
https://github.com/eclipse/che/issues/14887

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>