### PR TITLE
che #15506 Adding RELEASE.md file with instructions for Major/Minor and  Service/Bugfix releases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,31 @@
+## Major / Minor Release
+
+- create a branch for the release e.g. `7.6.x`
+- provide a [PR](https://github.com/eclipse/che-machine-exec/pull/66) with bumping the [VERSION](https://github.com/eclipse/che-machine-exec/blob/master/VERSION) file to the `7.6.x` branch
+- [![Release Build Status](https://ci.centos.org/buildStatus/icon?subject=release&job=devtools-che-machine-exec-release/)](https://ci.centos.org/job/devtools-che-machine-exec-release/) CI is triggered based on the changes in the [release](https://github.com/eclipse/che-machine-exec/tree/release) branch (not `7.6.x`).
+
+In order to trigger the CI once the [PR](https://github.com/eclipse/che-machine-exec/pull/66) is merged to the `7.6.x` one needs to:
+
+```
+ git fetch origin 7.6.x:7.6.x
+ git checkout 7.6.x
+ git branch release -f 
+ git push origin release -f
+```
+
+CI will build an image from the [`release`](https://github.com/eclipse/che-machine-exec/tree/release) branch and push it to [quay.io](https://quay.io/organization/eclipse) e.g [quay.io/eclipse/che-machine-exec:7.6.0](https://quay.io/repository/eclipse/che-machine-exec?tab=tags&tag=7.6.0)
+
+The last thing is the tag `7.6.0` creation from the `7.6.x` branch
+
+```
+git checkout 7.6.x
+git tag 7.6.0
+git push origin 7.6.0
+```
+
+After the release, the `VERSION` file should be bumped in the master e.g. [`7.7.0-SNAPSHOT`](https://github.com/eclipse/che-machine-exec/pull/67)
+
+## Service / Bugfix  Release
+
+The release process is very similar to the Major / Minor one, just the existing branch should be used for the `VERSION` bump e.g. `7.3.x` branch for `7.3.3` - [PR](https://github.com/eclipse/che-machine-exec/pull/62) example.
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 ## Major / Minor Release
 
 - create a branch for the release e.g. `7.6.x`
-- provide a [PR](https://github.com/eclipse/che-machine-exec/pull/66) with bumping the [VERSION](https://github.com/eclipse/che-machine-exec/blob/master/VERSION) file to the `7.6.x` branch
+- provide a [PR](https://github.com/eclipse/che-machine-exec/pull/66) with bumping the [VERSION](https://github.com/eclipse/che-machine-exec/blob/master/VERSION) file to the `7.6.x` branch (changing `7.6.0-SNAPSHOT` to `7.6.0`)
 - [![Release Build Status](https://ci.centos.org/buildStatus/icon?subject=release&job=devtools-che-machine-exec-release/)](https://ci.centos.org/job/devtools-che-machine-exec-release/) CI is triggered based on the changes in the [release](https://github.com/eclipse/che-machine-exec/tree/release) branch (not `7.6.x`).
 
 In order to trigger the CI once the [PR](https://github.com/eclipse/che-machine-exec/pull/66) is merged to the `7.6.x` one needs to:


### PR DESCRIPTION
PR contains `RELEASE.md` with a detailed set of instructions for  Major/Minor and  Service/Bugfix releases of the 'che-machine-exec' plugin
issue https://github.com/eclipse/che/issues/15506