### PR TITLE
Fix shell detection when shell is empty value.

### DIFF
--- a/shell/shell_info_parser.go
+++ b/shell/shell_info_parser.go
@@ -57,7 +57,7 @@ func (*execInfoParser) ParseShellFromEtcPassWd(etcPassWdContent string, userId s
 
 	result := rgExp.FindStringSubmatch(etcPassWdContent)
 	// First group it's all expression, second on it's "?P<ShellPath>"
-	if len(result) != 2 {
+	if len(result) != 2 || result[1] == "" {
 		return "", errors.New("unable to find default shell")
 	}
 

--- a/shell/shell_info_parser_test.go
+++ b/shell/shell_info_parser_test.go
@@ -47,7 +47,7 @@ func TestShouldFailParseUIDWithEmptyContent(t *testing.T) {
 	assert.Equal(t, "", uid)
 }
 
-func TestShouldShellFromEtcPassWd(t *testing.T) {
+func TestShouldParseShellFromEtcPassWd(t *testing.T) {
 	etcPasswdContent := "user:x:1000:1000:user,,,:/home/user:/bin/bash\n" +
 		"nvidia-persistenced:x:121:127:NVIDIA Persistence Daemon,,,:/nonexistent:/sbin/nologin\n" +
 		"libvirt-qemu:x:64055:128:Libvirt Qemu,,,:/var/lib/libvirt:/usr/sbin/nologin\n" +
@@ -61,7 +61,7 @@ func TestShouldShellFromEtcPassWd(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestShouldShellFromEtcPassWd2(t *testing.T) {
+func TestShouldParseShellFromEtcPassWd2(t *testing.T) {
 	etcPasswdContent := "nvidia-persistenced:x:121:127:NVIDIA Persistence Daemon,,,:/nonexistent:/sbin/nologin\n" +
 		"libvirt-qemu:x:64055:128:Libvirt Qemu,,,:/var/lib/libvirt:/usr/sbin/nologin\n" +
 		"user:x:1000:1000:user,,,:/home/user:/bin/bash\n" +
@@ -75,7 +75,7 @@ func TestShouldShellFromEtcPassWd2(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestShouldShellFromEtcPassWd3(t *testing.T) {
+func TestShouldParseShellFromEtcPassWd3(t *testing.T) {
 	etcPasswdContent := "nvidia-persistenced:x:121:127:NVIDIA Persistence Daemon,,,:/nonexistent:/sbin/nologin\n" +
 		"libvirt-qemu:x:64055:128:Libvirt Qemu,,,:/var/lib/libvirt:/usr/sbin/nologin\n" +
 		"root:x:0:0:root:/root:/bin/bash" +
@@ -87,6 +87,20 @@ func TestShouldShellFromEtcPassWd3(t *testing.T) {
 
 	assert.Equal(t, "/bin/bash", shell)
 	assert.Nil(t, err)
+}
+
+func TestShouldFailParseShellBecauseEmptyValue(t *testing.T) {
+	etcPasswdContent := "nvidia-persistenced:x:121:127:NVIDIA Persistence Daemon,,,:/nonexistent:/sbin/nologin\n" +
+		"libvirt-qemu:x:64055:128:Libvirt Qemu,,,:/var/lib/libvirt:/usr/sbin/nologin\n" +
+		"root:x:0:0:root:/root:/bin/bash" +
+		"user:x:1000:1000:user,,,:/home/user:\n"
+	uid := "1000"
+
+	shellExecInfoParser := &execInfoParser{}
+	shell, err := shellExecInfoParser.ParseShellFromEtcPassWd(etcPasswdContent, uid)
+
+	assert.Equal(t, "", shell)
+	assert.NotNil(t, err)
 }
 
 func TestShouldFailParseShellFromEtcPasswdBecauseUIDIsNotExists(t *testing.T) {


### PR DESCRIPTION
Fix shell detection when shell is empty value:

```
user:x:1000:1000:user,,,:/home/user:
```

Last item after `:` (shell) is empty

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>