### PR TITLE
Fix return of carriage during printing of welcome title

### DIFF
--- a/cloud-shell/src/index.ts
+++ b/cloud-shell/src/index.ts
@@ -24,7 +24,7 @@ const attachUrl = hostUrl + '/attach';
 const terminal: CloudShellTerminal = new CloudShellTerminal();
 
 terminal.open(terminalElem);
-terminal.sendText('Welcome to the Cloud Shell.\n');
+terminal.sendLine('Welcome to the Cloud Shell.');
 
 console.log(connectUrl);
 const rpcConnecton = new JsonRpcConnection(connectUrl);

--- a/cloud-shell/src/terminal.ts
+++ b/cloud-shell/src/terminal.ts
@@ -66,6 +66,10 @@ export class CloudShellTerminal {
         this.xterm.write(text);
     }
 
+    sendLine(text: string) {
+        this.xterm.writeln(text);
+    }
+
     dispose() {
         this.xterm.dispose();
     }


### PR DESCRIPTION
Fix return of carriage during the printing of welcome title.
Thank @AndrienkoAleksandr for helping prepare a quick fix!

Before:
![old](https://user-images.githubusercontent.com/5887312/73355401-beb5af80-42a0-11ea-9b96-53c0b6540138.gif)


After:
![new](https://user-images.githubusercontent.com/5887312/73355403-c1180980-42a0-11ea-9b20-ed0340f8ddcb.gif)

### Devfile to test changes:

```yaml
metadata:
  name: cloud-shell
components:
  - type: cheEditor
    reference: >-
      https://gist.githubusercontent.com/sleshchenko/c1cd908303b12684ac21e616c4cee1e9/raw/7e1dc5d106024af49fb1009af0c18792d2b1e328/meta.yaml
    alias: cloudShell
  - memoryLimit: 256Mi
    type: dockerimage
    alias: dev
    image: 'eclipse/che-remote-plugin-openshift-connector-0.0.17:7.2.0'
    env:
      - value: '\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]'
        name: PS1
apiVersion: 1.0.0

```