### PR TITLE
Make che-machine-exec listen only on localhost by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&url, "url", ":4444", "Host:Port address.")
+	flag.StringVar(&url, "url", "127.0.0.1:4444", "Host:Port address.")
 	flag.StringVar(&staticPath, "static", "", "/home/user/frontend - absolute path to folder with static resources.")
 }
 


### PR DESCRIPTION
eclipse/che#15651 (and PR eclipse/che#15890) change the deployment of the JWT proxy in the che-server such that it is co-located in the workspace pod and the deployment of secure endpoints such that no services are created for them and the endpoints are assumed to be listening solely on `127.0.0.1`.

This makes the `che-machine-exec` conform to those assumptions and also makes it accessible ONLY through JWT proxy in the workspace.