### PR TITLE
Collect errors while trying to exec into containers and print them

### DIFF
--- a/exec/kubernetes_exec_manager.go
+++ b/exec/kubernetes_exec_manager.go
@@ -93,11 +93,13 @@ func (manager *KubernetesExecManager) Create(machineExec *model.MachineExec) (in
 	if err != nil {
 		return -1, err
 	}
+	var errors []error
 	for _, containerInfo := range containersInfo {
 		err = manager.doCreate(machineExec, containerInfo, k8sAPI)
 		if err != nil {
 			//attempt to initialize terminal in this container failed
 			//proceed to next one
+			errors = append(errors, err)
 			continue
 		}
 		logrus.Printf("%s is successfully initialized in auto discovered container %s/%s", machineExec.Cmd,
@@ -109,7 +111,7 @@ func (manager *KubernetesExecManager) Create(machineExec *model.MachineExec) (in
 	for _, c := range containersInfo {
 		containers = append(containers, c.PodName+"\\"+c.ContainerName)
 	}
-	return -1, fmt.Errorf("failed to initialize terminal in any of {%s}", strings.Join(containers, ", "))
+	return -1, fmt.Errorf("failed to initialize terminal in any of {%s} -- errors: %v", strings.Join(containers, ", "), errors)
 }
 
 func (manager *KubernetesExecManager) doCreate(machineExec *model.MachineExec, containerInfo *model.ContainerInfo, k8sAPI *client.K8sAPI) error {

--- a/exec/kubernetes_exec_manager.go
+++ b/exec/kubernetes_exec_manager.go
@@ -15,11 +15,12 @@ package exec
 import (
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/eclipse/che-machine-exec/api/model"
 	"github.com/eclipse/che-machine-exec/client"
@@ -93,13 +94,13 @@ func (manager *KubernetesExecManager) Create(machineExec *model.MachineExec) (in
 	if err != nil {
 		return -1, err
 	}
-	var errors []error
+	var errors map[string]error
 	for _, containerInfo := range containersInfo {
 		err = manager.doCreate(machineExec, containerInfo, k8sAPI)
 		if err != nil {
 			//attempt to initialize terminal in this container failed
 			//proceed to next one
-			errors = append(errors, err)
+			errors[containerInfo.ContainerName] = err
 			continue
 		}
 		logrus.Printf("%s is successfully initialized in auto discovered container %s/%s", machineExec.Cmd,
@@ -111,7 +112,11 @@ func (manager *KubernetesExecManager) Create(machineExec *model.MachineExec) (in
 	for _, c := range containersInfo {
 		containers = append(containers, c.PodName+"\\"+c.ContainerName)
 	}
-	return -1, fmt.Errorf("failed to initialize terminal in any of {%s} -- errors: %v", strings.Join(containers, ", "), errors)
+	var buf strings.Builder
+	for container, err := range errors {
+		buf.WriteString(fmt.Sprintf("- %s: %s\n", container, err.Error()))
+	}
+	return -1, fmt.Errorf("failed to initialize terminal in any of {%s} -- errors: \n%s", strings.Join(containers, ", "), buf.String())
 }
 
 func (manager *KubernetesExecManager) doCreate(machineExec *model.MachineExec, containerInfo *model.ContainerInfo, k8sAPI *client.K8sAPI) error {


### PR DESCRIPTION
Collect any errors encountered while trying to open an exec into each container; if we cannot create an exec, print all errors encountered to aid debugging.

For successful connection, nothing is printed.

This is useful in case of e.g. a rbac issue; if the serviceaccount being used by machine-exec doesn't have enough permissions, it's clear from the logs.