### PR TITLE
Display exec error or exit information in the UI cloud shell.

### DIFF
--- a/cloud-shell/src/const.ts
+++ b/cloud-shell/src/const.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+export namespace ANSIControlSequences {
+    export const RESET_COLOR = '\u001b[0m'
+    export const RED_COLOR = '\u001b[31m'
+    export const GREEN_COLOR = '\u001b[32m'
+ }

--- a/cloud-shell/src/terminal-protocol.ts
+++ b/cloud-shell/src/terminal-protocol.ts
@@ -8,6 +8,9 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+export const EXIT_METHOD: string = 'onExecExit';
+export const ERROR_METHOD: string = 'onExecError';
+
 export interface MachineIdentifier {
     machineName: string,
     workspaceId: string
@@ -20,6 +23,16 @@ export interface MachineExec {
     cols: number,
     rows: number,
     id?: number
+}
+
+export interface ExecExitEvent {
+    id: number;
+    code: number;
+}
+
+export interface ExecErrorEvent {
+    id: number;
+    stack: string;
 }
 
 export interface IdParam {


### PR DESCRIPTION
### Referenced issue:
https://github.com/eclipse/che/issues/16249


Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>