### PR TITLE
fix bad English, broken links, s/CHE/Che/g...

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ $ docker build --no-cache -t eclipse/che-machine-exec .
    - [Setting Up the Virtualization Environment](https://docs.okd.io/latest/minishift/getting-started/setting-up-virtualization-environment.html)
 
 3. Install the `oc` tool:
-  1. [Download the `oc` binary for your platform](https://mirror.openshift.com/pub/openshift-v3/clients).
-  2. Extract and apply this binary path to the `PATH` system environment variable.
-  3. The `oc` tool is now availiable from the terminal:
+  - [Download the `oc` binary for your platform](https://mirror.openshift.com/pub/openshift-v3/clients).
+  - Extract and apply this binary path to the `PATH` system environment variable.
+  - The `oc` tool is now availiable from the terminal:
  ```
  $ oc version
  oc v3.11.213
@@ -87,39 +87,41 @@ This command activates an OpenShift context to use the Minishift instance:
 2. Install a minikube virtual machine on your computer. See the [minikube README](https://github.com/kubernetes/minikube/blob/master/README.md).
 
 3. Deploy Eclipse Che using Helm:
++
    1. [Install Helm](https://github.com/kubernetes/helm/blob/master/docs/install.md).
++ 
    2. Start minikube:
 ```
 $ minikube start --cpus 2 --memory 8192 --extra-config=apiserver.authorization-mode=RBAC
 ```
-
++
    3. Go to the `helm/che` directory:
 ```
 $ cd ~/projects/che/deploy/kubernetes/helm/che
 ```
-
++
    4. Add the **cluster-admin** role for the `kube-system:default` account:
 ```
-$ kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+$ kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin \
+  --serviceaccount=kube-system:default
 ```
-
++
    5. Set the default Kubernetes context:
 ```
 $ kubectl config use-context minikube
 ```
-
-   6. Install tiller on the cluster:
-      1. Create a [tiller serviceAccount]:
++
+   6. To install tiller on the cluster, first create a tiller serviceAccount:
 ```
 $ kubectl create serviceaccount tiller --namespace kube-system
 ```
-
-      2. Bind it to the **cluster-admin** role:
++
+   7. Then bind it to the **cluster-admin** role:
 ```
 $ kubectl apply -f ./tiller-rbac.yaml
 ```
-
-   7. Install tiller itself:
++
+   8. Install tiller itself:
 ```
 $ helm init --service-account tiller
 ```

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 [![Nightly Build Status](https://ci.centos.org/buildStatus/icon?subject=nightly&job=devtools-che-machine-exec-nightly)](https://ci.centos.org/job/devtools-che-machine-exec-nightly/)
 [![Release Build Status](https://ci.centos.org/buildStatus/icon?subject=release&job=devtools-che-machine-exec-release/)](https://ci.centos.org/job/devtools-che-machine-exec-release/)
 
-# CHE machine exec
+# Che machine exec
 
-Go-lang server side to creation machine-execs for Eclipse CHE workspaces.
-Uses to spawn terminal or command processes.
+Golang server that creates machine-execs for Eclipse Che workspaces.
 
-CHE machine exec uses json-rpc protocol to communication with client.
+Used to spawn terminals or command processes.
+
+Che machine exec uses json-rpc protocol to communicate with client.
 
 ## Build docker image
 
@@ -17,33 +18,23 @@ Build docker image with che-machine-exec manually:
 docker build --no-cache -t eclipse/che-machine-exec .
 ```
 
-## Test che-machine-exec on the local Openshift
+## Test che-machine-exec on Openshift
 
-To test che-machine-exec you need deploy Eclipse CHE to the openshift locally. [Prepare Eclipse CHE to deploy](#prepare-eclipse-che-to-deploy)
+First, [build Eclipse Che Assembly](#build-eclipse-che-assembly).
 
-To deploy Eclipse CHE to the local running openshift you can use [ocp.sh sript](https://github.com/eclipse/che/blob/master/deploy/openshift/ocp.sh).
+To deploy Eclipse Che to OpenShift you can use [these templates](https://github.com/eclipse/che/blob/master/deploy/openshift/).
 
-Move to the ocp.sh script:
-
-```bash
-cd ~/projects/che/deploy/openshift/
-```
-
- Run ocp.sh with arguments:
-
-```bash
-./ocp.sh --run-ocp --deploy-che --no-pull --debug --deploy-che-plugin-registry --multiuser
-```
-In the output you will get link to the deployed Eclipse CHE project. Use it to login to Eclipse CHE.
+In the output you will get link to the deployed Eclipse Che project. Use it to login to Eclipse Che.
 > Notice: for ocp.sh you could use argument `--setup-ocp-oauth`, but in this case you should use "Openshift v3" auth on the login page.
 
 Register new user on the login page. After login you will be redirected to
-the Eclipse CHE user dashboard.
+the Eclipse Che user dashboard.
 
-Create new workspace from openshift stack 'Java Theia on OpenShift' or 'CHE 7' stack. Run workspace. When workspace will be running you will see Theia IDE. Then you can [test che-machine-exec with help che-theia-terminal-extension](#test-che-machine-exec-with-help-eclipse-che-theia-terminal) and [test che-machine-exec with help che-theia-task-plugin](#test-che-machine-exec-with-help-che-theia-task-plugin)
+Create an Eclipse Che 7.x workspace using the default Theia IDE. Then you can [test che-machine-exec with help che-theia-terminal-extension](#test-che-machine-exec-with-help-eclipse-che-theia-terminal) and [test che-machine-exec with help che-theia-task-plugin](#test-che-machine-exec-with-help-che-theia-task-plugin)
 
-## Test on the Minishift
-To test che-machine-exec you need deploy Eclipse CHE to the Minishift. [Prepare Eclipse CHE to deploy](#prepare-eclipse-che-to-deploy).
+## Test on Minishift
+
+First, [build Eclipse Che Assembly](#build-eclipse-che-assembly).
 
 Install minishift with help this instractions:
  - https://docs.okd.io/latest/minishift/getting-started/preparing-to-install.html
@@ -76,23 +67,23 @@ $ minishift start --memory=8GB
 ```
 
 From this command output you need:
- - Minishift master url. In this case it's `https://192.168.42.159:8443`. Let's call it 'CHE_INFRA_KUBERNETES_MASTER__URL'. We can store this variable in the terminal session to use it for next commands:
+ - Minishift master url. In this case it's `https://192.168.42.159:8443`. Let's call it 'Che_INFRA_KUBERNETES_MASTER__URL'. We can store this variable in the terminal session to use it for next commands:
 
  ```bash
- export CHE_INFRA_KUBERNETES_MASTER__URL=https://192.168.42.162:8443
+ export Che_INFRA_KUBERNETES_MASTER__URL=https://192.168.42.162:8443
  ```
 > Note: in case if you delete minishift virtual machine(`minishift delete`) and create it again, this url will be changed.
 
-Register new user on the CHE_INFRA_KUBERNETES_MASTER__URL page.
+Register new user on the Che_INFRA_KUBERNETES_MASTER__URL page.
 
 Login to minishift with help oc, use new user login and password for it:
 
 ```bash
-$ oc login --server=${CHE_INFRA_KUBERNETES_MASTER__URL}
+$ oc login --server=${Che_INFRA_KUBERNETES_MASTER__URL}
 ```
-This command activates openshift context to use minishift instance:
+This command activates OpenShift context to use minishift instance:
 
-To deploy Eclipse CHE you can use [deploy_che.sh script](https://github.com/eclipse/che/blob/master/deploy/openshift/deploy_che.sh).
+To deploy Eclipse Che you can use [deploy_che.sh script](https://github.com/eclipse/che/blob/master/deploy/openshift/deploy_che.sh).
 
 Move to deploy_che.sh script:
 ```
@@ -102,19 +93,18 @@ cd ~/projects/che/deploy/openshift
 Run deploy_che.sh script with arguments:
 
 ```bash
-export CHE_INFRA_KUBERNETES_MASTER__URL=${CHE_INFRA_KUBERNETES_MASTER__URL} && ./deploy_che.sh --no-pull --debug --multiuser
+export Che_INFRA_KUBERNETES_MASTER__URL=${Che_INFRA_KUBERNETES_MASTER__URL} && ./deploy_che.sh --no-pull --debug --multiuser
 ```
 
-Create new workspace from openshift stack 'Java Theia on OpenShift' or
-'CHE 7' stack. Run workspace. When workspace will be running you will see Theia IDE. Then you can [test che-machine-exec with help che-theia-terminal-extension](#test-che-machine-exec-with-help-eclipse-che-theia-terminal) and [test che-machine-exec with help che-theia-task-plugin](#test-che-machine-exec-with-help-che-theia-task-plugin)
+Create an Eclipse Che 7.x workspace using the default Theia IDE. Then you can [test che-machine-exec with help che-theia-terminal-extension](#test-che-machine-exec-with-help-eclipse-che-theia-terminal) and [test che-machine-exec with help che-theia-task-plugin](#test-che-machine-exec-with-help-che-theia-task-plugin)
 
 ## Test on the Kubernetes (MiniKube)
 
-To test che-machine-exec you need deploy Eclipse CHE to the Minikube cluster. [Prepare Eclipse CHE to deploy](#prepare-eclipse-che-to-deploy).
+First, [build Eclipse Che Assembly](#build-eclipse-che-assembly).
 
 Install minikube virtual machine on your computer: https://github.com/kubernetes/minikube/blob/master/README.md
 
-You can deploy Eclipse CHE with help helm. So, [install Helm](https://github.com/kubernetes/helm/blob/master/docs/install.md)
+You can deploy Eclipse Che with help helm. So, [install Helm](https://github.com/kubernetes/helm/blob/master/docs/install.md)
 
 Start new minikube:
 ```bash
@@ -152,36 +142,36 @@ kubectl config use-context minikube
   minikube addons enable ingress
   ```
 
-There are two configurations to deploy Eclipse CHE on the Kubernetes:
- - first one: for each new workspace Eclipse CHE creates separated namespace:
+There are two configurations to deploy Eclipse Che on the Kubernetes:
+ - first one: for each new workspace Eclipse Che creates separated namespace:
     ```bash
       helm upgrade --install che --namespace che ./
     ```
- - second one: Eclipse CHE creates workspace in the same namespace:
+ - second one: Eclipse Che creates workspace in the same namespace:
     ```bash
     helm upgrade --install che --namespace=che --set global.cheWorkspacesNamespace=che ./
     ```
 
-> Info: To delploy multi-user CHE you can use parameter: `-f ./values/multi-user.yaml`. Also you can set ingress domain with help parameter: `--set global.ingressDomain=<domain>`
+> Info: To deploy multi-user Che you can use parameter: `-f ./values/multi-user.yaml`. Also you can set ingress domain with help parameter: `--set global.ingressDomain=<domain>`
 
-> Notice: You can track deploy CHE with help Minikube dashboard:
+> Note: You can track deploy Che with help Minikube dashboard:
   ```bash
   minikube dashboard
   ```
 
-Create new workspace from stack 'CHE 7'. Run workspace. When workspace will be running you will see Theia IDE. Then you can [test che-machine-exec with help che-theia-terminal-extension](#test-che-machine-exec-with-help-eclipse-che-theia-terminal) and [test che-machine-exec with help che-theia-task-plugin](#test-che-machine-exec-with-help-che-theia-task-plugin)
+Create an Eclipse Che 7.x workspace using the default Theia IDE. Then you can [test che-machine-exec with help che-theia-terminal-extension](#test-che-machine-exec-with-help-eclipse-che-theia-terminal) and [test che-machine-exec with help che-theia-task-plugin](#test-che-machine-exec-with-help-che-theia-task-plugin)
 
-## Prepare Eclipse CHE to deploy
+## Build Eclipse Che Assembly
 
-> Requiements: installed java 8 or higher and maven 3.3.0 or higher
+> Requiements: installed java 8 or higher and maven 3.5 or higher
 
-First of all clone Eclipse CHE:
+First, clone Eclipse Che:
 
 ```
 $ git clone https://github.com/eclipse/che.git ~/projects/che
 ```
 
-For test purpose it's not nessure build all Eclipse CHE, build 'assembly-main' maven module is pretty enough:
+You can save time by simply building the `assembly-main` module, rather than the whole Eclipse Che project.
 
 ```
 $ cd ~/projects/che/assembly/assembly-main
@@ -189,14 +179,17 @@ $ mvn clean install -DskipTests
 ```
 
 ## Test che-machine-exec with help eclipse-che-theia-terminal
-Eclipse CHE workspace created from Theia stack contains included che-theia-terminal-extension. With help this extension you can test che-machine-exec.
 
-Create new terminal with help main menu of the Theia: `Terminal` => `Open Terminal in specific container`. After that IDE will propose you select machine to creation terminal. Select one of the machines by click. After that Theia should create new terminal on the bottom panel.
-Or you could use command palette: `Ctrl + Shift + P` and type `terminal`. Then you could select with help keys `Arrow Up` or `Arrow Down` command for terminal creation and launch it by click on `Enter`.
+Eclipse Che 7.x workspaces using Theia IDE include the che-theia-terminal-extension. You can use this to test che-machine-exec.
+
+In a Che 7 workspace, select: `Terminal` => `Open Terminal in specific container`. Select a container to create new terminal on the bottom panel.
+
+Can also use command palette: `Ctrl + Shift + P` and type `terminal`, then select a container with arrow keys.
 
 ## Test che-machine-exec with help che-theia-task-plugin
 
-Eclipse CHE workspace created from Theia stack contains included che-theia-task-plugin. With help this plugin you can test che-machine-exec.
+Eclipse Che 7.x workspaces using Theia IDE include che-theia-task-plugin. You can use this to test che-machine-exec.
+
 Create new Theia task for your project: in the project root create folder `.theia`. Create `tasks.json` file in the folder `.theia` with such content:
 
 ```bash
@@ -216,6 +209,6 @@ After that Theia should display widget with output content: 'echo hello'
 ## CI
 The following [CentOS CI jobs](https://ci.centos.org/) are associated with the repository:
 
-- [![Master Build Status](https://ci.centos.org/buildStatus/icon?subject=master&job=devtools-che-machine-exec-build-master/)](https://ci.centos.org/job/devtools-che-machine-exec-build-master/) - builds CentOS images on each commit to the [`master`](https://github.com/eclipse/che-machine-exec/tree/master) branch and pushes them to [quay.io](https://quay.io/organization/eclipse).
+- [![Master Build Status](https://ci.centos.org/buildStatus/icon?subject=master&job=devtools-che-machine-exec-build-master/)](https://ci.centos.org/job/devtools-che-machine-exec-build-master/) - builds CentOS images on each commit to [`master`](https://github.com/eclipse/che-machine-exec/tree/master) branch and pushes them to [quay.io](https://quay.io/organization/eclipse).
 - [![Nightly Build Status](https://ci.centos.org/buildStatus/icon?subject=nightly&job=devtools-che-machine-exec-nightly)](https://ci.centos.org/job/devtools-che-machine-exec-nightly/) - builds CentOS images and pushes them to [quay.io](https://quay.io/organization/eclipse) on a daily basis from the [`master`](https://github.com/eclipse/che-machine-exec/tree/master) branch.
 - [![Release Build Status](https://ci.centos.org/buildStatus/icon?subject=release&job=devtools-che-machine-exec-release/)](https://ci.centos.org/job/devtools-che-machine-exec-release/) -  builds images from the [`release`](https://github.com/eclipse/che-machine-exec/tree/release) branch and pushes them to [quay.io](https://quay.io/organization/eclipse).

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ $ docker build --no-cache -t eclipse/che-machine-exec .
 1. [Build Eclipse Che Assembly](#building-eclipse-che-assembly).
 
 2. Install Minishift using the following instractions:
-   - [Preparing to Install Minishift](https://docs.okd.io/latest/minishift/getting-started/preparing-to-install.html)
-   - [Setting Up the Virtualization Environment](https://docs.okd.io/latest/minishift/getting-started/setting-up-virtualization-environment.html)
+    - [Preparing to Install Minishift](https://docs.okd.io/latest/minishift/getting-started/preparing-to-install.html)
+    - [Setting Up the Virtualization Environment](https://docs.okd.io/latest/minishift/getting-started/setting-up-virtualization-environment.html)
 
 3. Install the `oc` tool:
-  - [Download the `oc` binary for your platform](https://mirror.openshift.com/pub/openshift-v3/clients).
-  - Extract and apply this binary path to the `PATH` system environment variable.
-  - The `oc` tool is now availiable from the terminal:
+    - [Download the `oc` binary for your platform](https://mirror.openshift.com/pub/openshift-v3/clients).
+    - Extract and apply this binary path to the `PATH` system environment variable.
+    - The `oc` tool is now availiable from the terminal:
  ```
  $ oc version
  oc v3.11.213

--- a/README.md
+++ b/README.md
@@ -67,19 +67,19 @@ $ minishift start --memory=8GB
 ```
 
 From this command output you need:
- - Minishift master url. In this case it's `https://192.168.42.159:8443`. Let's call it 'Che_INFRA_KUBERNETES_MASTER__URL'. We can store this variable in the terminal session to use it for next commands:
+ - Minishift master url. In this case it's `https://192.168.42.159:8443`, or `CHE_INFRA_KUBERNETES_MASTER__URL`. We can store this variable in the terminal session to use it for next commands:
 
  ```bash
- export Che_INFRA_KUBERNETES_MASTER__URL=https://192.168.42.162:8443
+ export CHE_INFRA_KUBERNETES_MASTER__URL=https://192.168.42.162:8443
  ```
 > Note: in case if you delete minishift virtual machine(`minishift delete`) and create it again, this url will be changed.
 
-Register new user on the Che_INFRA_KUBERNETES_MASTER__URL page.
+Register new user on the `CHE_INFRA_KUBERNETES_MASTER__URL` page.
 
 Login to minishift with help oc, use new user login and password for it:
 
 ```bash
-$ oc login --server=${Che_INFRA_KUBERNETES_MASTER__URL}
+$ oc login --server=${CHE_INFRA_KUBERNETES_MASTER__URL}
 ```
 This command activates OpenShift context to use minishift instance:
 
@@ -93,7 +93,7 @@ cd ~/projects/che/deploy/openshift
 Run deploy_che.sh script with arguments:
 
 ```bash
-export Che_INFRA_KUBERNETES_MASTER__URL=${Che_INFRA_KUBERNETES_MASTER__URL} && ./deploy_che.sh --no-pull --debug --multiuser
+export CHE_INFRA_KUBERNETES_MASTER__URL=${CHE_INFRA_KUBERNETES_MASTER__URL} && ./deploy_che.sh --no-pull --debug --multiuser
 ```
 
 Create an Eclipse Che 7.x workspace using the default Theia IDE. Then you can [test che-machine-exec with help che-theia-terminal-extension](#test-che-machine-exec-with-help-eclipse-che-theia-terminal) and [test che-machine-exec with help che-theia-task-plugin](#test-che-machine-exec-with-help-che-theia-task-plugin)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ $ docker build --no-cache -t eclipse/che-machine-exec .
 
 2. Deploy Eclipse Che on OpenShift ([example templates](https://github.com/eclipse/che/blob/master/deploy/openshift/)).
    The output contains a link to the deployed Eclipse Che project. Use it to log in to Eclipse Che.
-> Note: For `ocp.sh`, the `--setup-ocp-oauth` is available. However, in this case, use "Openshift v3" authentication on the login page.
 
 3. Register a new user on the login page. After login, you are redirected to the Eclipse Che user dashboard.
 
@@ -35,13 +34,13 @@ $ docker build --no-cache -t eclipse/che-machine-exec .
    - [Setting Up the Virtualization Environment](https://docs.okd.io/latest/minishift/getting-started/setting-up-virtualization-environment.html)
 
 3. Install the `oc` tool:
-  1. [Download the `oc` binary for your platform](https://github.com/openshift/origin/releases).
+  1. [Download the `oc` binary for your platform](https://mirror.openshift.com/pub/openshift-v3/clients).
   2. Extract and apply this binary path to the `PATH` system environment variable.
   3. The `oc` tool is now availiable from the terminal:
  ```
  $ oc version
- oc v3.9.0+191fece
- kubernetes v1.9.1+a0ce1bc657
+ oc v3.11.213
+ kubernetes v1.11.0+d4cacc0
  features: Basic-Auth GSSAPI Kerberos SPNEGO
  ```
 

--- a/README.md
+++ b/README.md
@@ -62,17 +62,17 @@ $ docker build --no-cache -t eclipse/che-machine-exec .
       oc login -u system:admin
 ```
 
-5. Store the Minishift master URL from the output of `minishift start` (`https://192.168.42.159:8443`) in the `Che_INFRA_KUBERNETES_MASTER__URL` variable:
+5. Store the Minishift master URL from the output of `minishift start` (`https://192.168.42.159:8443`) in the `CHE_INFRA_KUBERNETES_MASTER__URL` variable:
 ```
-$ export Che_INFRA_KUBERNETES_MASTER__URL=https://192.168.42.162:8443
+$ export CHE_INFRA_KUBERNETES_MASTER__URL=https://192.168.42.162:8443
 ```
 > Note: When you delete the Minishift virtual machine (`minishift delete`) and create it again, this URL changes.
 
-6. Register a new user on the `Che_INFRA_KUBERNETES_MASTER__URL` page.
+6. Register a new user on the `CHE_INFRA_KUBERNETES_MASTER__URL` page.
 
 7. Log in to Minishift using `oc`. Use the new username and password for it:
 ```
-$ oc login --server=${Che_INFRA_KUBERNETES_MASTER__URL}
+$ oc login --server=${CHE_INFRA_KUBERNETES_MASTER__URL}
 ```
 This command activates an OpenShift context to use the Minishift instance:
 
@@ -83,7 +83,7 @@ $ cd ~/projects/che/deploy/openshift
 ```
    2. Run deploy_che.sh script with arguments:
 ```
-$ export Che_INFRA_KUBERNETES_MASTER__URL=${Che_INFRA_KUBERNETES_MASTER__URL} && \
+$ export CHE_INFRA_KUBERNETES_MASTER__URL=${CHE_INFRA_KUBERNETES_MASTER__URL} && \
 ./deploy_che.sh --no-pull --debug --multiuser
 ```
 9. Create an Eclipse Che 7.x workspace using the default Che-Theia IDE. Then [test che-machine-exec using che-theia-terminal-extension](#testing-che-machine-exec-using-che-theia-terminal) and [test che-machine-exec using che-theia-task-plugin](#testing-che-machine-exec-using-che-theia-task-plugin).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Build docker image with che-machine-exec manually:
 docker build --no-cache -t eclipse/che-machine-exec .
 ```
 
-## Test che-machine-exec on Openshift
+## Test che-machine-exec on OpenShift
 
 First, [build Eclipse Che Assembly](#build-eclipse-che-assembly).
 

--- a/README.md
+++ b/README.md
@@ -75,16 +75,9 @@ $ oc login --server=${CHE_INFRA_KUBERNETES_MASTER__URL}
 ```
 This command activates an OpenShift context to use the Minishift instance:
 
-8. Deploy Eclipse Che using the [deploy_che.sh script](https://github.com/eclipse/che/blob/master/deploy/openshift/deploy_che.sh):
-   1. Move to deploy_che.sh script:
-```
-$ cd ~/projects/che/deploy/openshift
-```
-   2. Run deploy_che.sh script with arguments:
-```
-$ export CHE_INFRA_KUBERNETES_MASTER__URL=${CHE_INFRA_KUBERNETES_MASTER__URL} && \
-./deploy_che.sh --no-pull --debug --multiuser
-```
+8. Deploy Eclipse Che on OpenShift ([example templates](https://github.com/eclipse/che/blob/master/deploy/openshift/)).
+   The output contains a link to the deployed Eclipse Che project. Use it to log in to Eclipse Che.
+
 9. Create an Eclipse Che 7.x workspace using the default Che-Theia IDE. Then [test che-machine-exec using che-theia-terminal-extension](#testing-che-machine-exec-using-che-theia-terminal) and [test che-machine-exec using che-theia-task-plugin](#testing-che-machine-exec-using-che-theia-task-plugin).
 
 ## Testing on Kubernetes using minikube


### PR DESCRIPTION
fix bad English, broken links, s/CHE/Che/g s/openshift/OpenShift/g, etc. in readme

Also update doc so we're not talking about the "Che 7 Theia stack" which was a beta feature in Che 6 and is now the default IDE in Che 7. 

Change-Id: I74b281dc668cb8ca5595b3d5a57ea5ac1bcfab69
Signed-off-by: nickboldt <nboldt@redhat.com>