### PR TITLE
Automatically create kubeconfig if bearer token is used

### DIFF
--- a/kubeconfig/kubeconfig.go
+++ b/kubeconfig/kubeconfig.go
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package kubeconfig
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+
+	"github.com/eclipse/che-machine-exec/exec"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+type KubeConfig struct {
+	APIVersion     string     `yaml:"apiVersion"`
+	Clusters       []Clusters `yaml:"clusters"`
+	Users          []Users    `yaml:"users"`
+	Contexts       []Contexts `yaml:"contexts"`
+	CurrentContext string     `yaml:"current-context"`
+	Kind           string     `yaml:"kind"`
+}
+
+type Clusters struct {
+	Cluster ClusterInfo `yaml:"cluster"`
+	Name    string      `yaml:"name"`
+}
+
+type ClusterInfo struct {
+	CertificateAuthority string `yaml:"certificate-authority"`
+	Server               string `yaml:"server"`
+}
+
+type Users struct {
+	Name string `yaml:"name"`
+	User User   `yaml:"user"`
+}
+
+type User struct {
+	Token string `yaml:"token"`
+}
+
+type Contexts struct {
+	Context Context `yaml:"context"`
+	Name    string  `yaml:"name"`
+}
+
+type Context struct {
+	Cluster   string `yaml:"cluster"`
+	Namespace string `yaml:"namespace"`
+	User      string `yaml:"user"`
+}
+
+func generateKubeConfig(token, server, namespace string) *KubeConfig {
+	return &KubeConfig{
+		APIVersion: "v1",
+		Clusters: []Clusters{
+			Clusters{
+				Cluster: ClusterInfo{
+					CertificateAuthority: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+					Server:               server,
+				},
+				Name: server,
+			},
+		},
+		Users: []Users{
+			Users{
+				Name: "developer",
+				User: User{
+					Token: token,
+				},
+			},
+		},
+		Contexts: []Contexts{
+			Contexts{
+				Context: Context{
+					Cluster:   server,
+					Namespace: namespace,
+					User:      "developer",
+				},
+				Name: "developer-context",
+			},
+		},
+		CurrentContext: "developer-context",
+		Kind:           "Config",
+	}
+}
+
+// CreateKubeConfig creates a kubeconfig located at os.Getenv("KUBECONFIG") and puts in the
+// values specific to the user IFF KUBECONFIG env variable is set
+func CreateKubeConfig(token string) {
+	kubeConfigLocation := os.Getenv("KUBECONFIG")
+	if kubeConfigLocation == "" {
+		return
+	}
+
+	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
+	if host == "" || port == "" {
+		return
+	}
+
+	namespace := exec.GetNamespace()
+
+	server := "https://" + net.JoinHostPort(host, port)
+	kubeconfig := generateKubeConfig(token, server, string(namespace))
+
+	bytes, err := yaml.Marshal(&kubeconfig)
+	if err != nil {
+		logrus.Error("error: %v", err)
+		return
+	}
+
+	err = ioutil.WriteFile(kubeConfigLocation, bytes, 0655)
+	if err != nil {
+		logrus.Error("error: %v", err)
+		return
+	}
+}

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/eclipse/che-go-jsonrpc"
+	jsonrpc "github.com/eclipse/che-go-jsonrpc"
 	"github.com/eclipse/che-go-jsonrpc/jsonrpcws"
 	"github.com/eclipse/che-machine-exec/api/events"
 	execRpc "github.com/eclipse/che-machine-exec/api/jsonrpc"
@@ -23,6 +23,7 @@ import (
 	"github.com/eclipse/che-machine-exec/api/model"
 	"github.com/eclipse/che-machine-exec/api/websocket"
 	"github.com/eclipse/che-machine-exec/cfg"
+	"github.com/eclipse/che-machine-exec/kubeconfig"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
@@ -46,7 +47,7 @@ func main() {
 
 		if cfg.UseBearerToken {
 			token = c.Request.Header.Get("X-Forwarded-Access-Token")
-
+			kubeconfig.CreateKubeConfig(token)
 		}
 
 		conn, err := jsonrpcws.Upgrade(c.Writer, c.Request)


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

This PR makes it so that a kubeconfig is created if UseBearerToken is true and KUBECONFIG env variable is set to where the kubeconfig should live. The kubeconfig will be regenerated every time the cloud shell is loaded in the browser

Before:
![cloud-shell-before](https://user-images.githubusercontent.com/8839537/80132669-04b1a500-856a-11ea-9bc8-9adcdc720e34.gif)

After:
![cloud-shell-after](https://user-images.githubusercontent.com/8839537/80132666-04b1a500-856a-11ea-9cf8-8a7c60ce2473.gif)

Related issue: https://github.com/eclipse/che/issues/16576