### PR TITLE
Close attach websocket connection on exec exit. Add pong handler.

### DIFF
--- a/ws-conn/err_handler.go
+++ b/ws-conn/err_handler.go
@@ -18,7 +18,7 @@ import (
 
 // Return true if err is normal close connection error(connection close client). Return false otherwise.
 // Note: In case if connection was close normally by client it's ok for us, we should not log error.
-func IsNormalWSError(err error) bool {
+func IsClosedByClientError(err error) bool {
 	normalCloseCodes := []int{ws.CloseGoingAway, ws.CloseNormalClosure, ws.CloseNoStatusReceived}
 	if closeErr, ok := err.(*ws.CloseError); ok {
 		for _, code := range normalCloseCodes {


### PR DESCRIPTION
Close attach websocket connection on exec exit. Add pong handler. Stop activity tracker on exec exit.

### Referenced issue:
  https://github.com/eclipse/che/issues/16601

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>