### PR TITLE
Do not use absolute references to work on single host/behind proxy

### DIFF
--- a/cloud-shell/src/index.ts
+++ b/cloud-shell/src/index.ts
@@ -18,10 +18,12 @@ import { ANSIControlSequences as CS } from './const';
 const terminalElem = document.getElementById('terminal-container');
 
 const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-const port = window.location.port ? `:${window.location.port}` : '';
-const hostUrl = `${protocol}://${window.location.host}${port}`;
-const connectUrl = hostUrl + '/connect';
-const attachUrl = hostUrl + '/attach';
+// CloudShell webapp expects to be available from /static/
+// So, API should be available at /static/../
+const basePath = (window.location.pathname.endsWith('/') ? window.location.pathname : window.location.pathname + '/') + '../';
+const websocketBaseUrl = `${protocol}://${window.location.host}${basePath}`;
+const connectUrl = websocketBaseUrl + 'connect';
+const attachUrl = websocketBaseUrl + 'attach';
 
 const terminal: CloudShellTerminal = new CloudShellTerminal();
 


### PR DESCRIPTION
This PR was done during work on integration CloudShell + OpenShift Console.

Unfortunately, we figure out that because of security constraints CloudShell frontend can't be run behind OpenShift Console Proxy, but in general it makes sense to avoid absolute references. In the Che perspective, it allows use CloudShell with SingleHost server exposure strategy.

It can be tested with the following Devfile

<details>

<summary>Devfile to test</summary>

```yaml
apiVersion: 1.0.0
metadata:
  name: cloud-shell
components:
  - alias: cloud-shell
    type: cheEditor
    reference: https://gist.githubusercontent.com/sleshchenko/c1ae73f1ab4b9c1ee325bf1d5751cfd8/raw/3b2f3c05a4ee082dcff34f54b203273c364b6bb6/meta.yaml
  - type: dockerimage
    memoryLimit: 256Mi
    alias: dev
    image: 'quay.io/eclipse/che-sidecar-openshift-connector:0.1.2-2601509'
    args: ["tail", "-f", "/dev/null"]
    env:
      - value: '\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]'
        name: PS1
```

</details>

I've made sure that it's possible to open CloudShell on the Che
![Screenshot_20200504_154646](https://user-images.githubusercontent.com/5887312/80967223-a5337f00-8e1e-11ea-8a46-754674ea9d4e.png)
