### PR TITLE
Use seperate namespace for getting k8sAPI and kubeconfig creation

### DIFF
--- a/exec/kubernetes_exec_manager.go
+++ b/exec/kubernetes_exec_manager.go
@@ -340,12 +340,13 @@ func (manager *KubernetesExecManager) CreateKubeConfig(initConfigParams *model.I
 
 	for _, containerInfo := range containersInfo {
 		if containerInfo.ContainerName == initConfigParams.ContainerName || initConfigParams.ContainerName == "" {
-			namespace := GetNamespace()
-			if initConfigParams.Namespace != "" {
-				namespace = initConfigParams.Namespace
+			currentNamespace := GetNamespace()
+			infoExecCreator := exec_info.NewKubernetesInfoExecCreator(currentNamespace, k8sAPI.GetClient().Core(), k8sAPI.GetConfig())
+
+			if initConfigParams.Namespace == "" {
+				initConfigParams.Namespace = currentNamespace
 			}
-			infoExecCreator := exec_info.NewKubernetesInfoExecCreator(namespace, k8sAPI.GetClient().Core(), k8sAPI.GetConfig())
-			err = kubeconfig.CreateKubeConfig(infoExecCreator, namespace, &initConfigParams.KubeConfigParams, containerInfo)
+			err = kubeconfig.CreateKubeConfig(infoExecCreator, &initConfigParams.KubeConfigParams, containerInfo)
 			if err != nil {
 				return err
 			}

--- a/kubeconfig/kubeconfig.go
+++ b/kubeconfig/kubeconfig.go
@@ -118,8 +118,8 @@ func createKubeConfigText(token, namespace, username string) (string, error) {
 
 // CreateKubeConfig creates a kubeconfig located at $KUBECONFIG if set.
 // If it is not set then fall back to $HOME/.kube/config
-func CreateKubeConfig(cmdRslv execInfo.InfoExecCreator, namespace string, kubeConfigParams *model.KubeConfigParams, containerInfo *model.ContainerInfo) error {
-	config, err := createKubeConfigText(kubeConfigParams.BearerToken, namespace, kubeConfigParams.Username)
+func CreateKubeConfig(cmdRslv execInfo.InfoExecCreator, kubeConfigParams *model.KubeConfigParams, containerInfo *model.ContainerInfo) error {
+	config, err := createKubeConfigText(kubeConfigParams.BearerToken, kubeConfigParams.Namespace, kubeConfigParams.Username)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously if you wanted to create a kubeconfig in a different namespace it would need pod/exec privileges. This PR fixes that so it uses the namespace you are in to get the k8sAPI and then the namespace passed into /exec/init is used in the creation of the kubeconfig.

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>