### PR TITLE
Fix build docker image command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Golang server that creates machine-execs for Eclipse Che workspaces. It is use
 To build a container image with che-machine-exec manually:
 
 ```
-$ docker build --no-cache -t eclipse/che-machine-exec .
+$ docker build --no-cache -t eclipse/che-machine-exec -f build/dockerfiles/Dockerfile .
 ```
 
 ## Testing che-machine-exec on OpenShift


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

This PR updates the build docker image command in the README to point to the dockerfile in the new location.

Right now you'll get:
```
$ docker build --no-cache -t eclipse/che-machine-exec
"docker build" requires exactly 1 argument.
See 'docker build --help'.

Usage:  docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile
```

After this PR it will successfully build