### PR TITLE
Add an ability to configure authenticated user-id

### DIFF
--- a/api/jsonrpc/handlers.go
+++ b/api/jsonrpc/handlers.go
@@ -14,10 +14,10 @@ package jsonrpc
 
 import (
 	"errors"
+	"github.com/eclipse/che-machine-exec/auth"
 
 	"github.com/eclipse/che-machine-exec/api/events"
 	"github.com/eclipse/che-machine-exec/api/model"
-	"github.com/eclipse/che-machine-exec/cfg"
 	"github.com/sirupsen/logrus"
 
 	"strconv"
@@ -52,11 +52,11 @@ var (
 
 func jsonRpcCreateExec(tunnel *jsonrpc.Tunnel, params interface{}, t jsonrpc.RespTransmitter) {
 	machineExec := params.(*model.MachineExec)
-	if cfg.UseBearerToken {
+	if auth.IsEnabled() {
 		if token, ok := tunnel.Attributes[BearerTokenAttr]; ok && len(token) > 0 {
 			machineExec.BearerToken = token
 		} else {
-			err := errors.New("Bearer token should not be an empty")
+			err := errors.New("bearer token should not be an empty")
 			logrus.Errorf(err.Error())
 			t.SendError(jsonrpc.NewArgsError(err))
 			return

--- a/api/model/model_types.go
+++ b/api/model/model_types.go
@@ -25,8 +25,6 @@ const (
 	// method names to send events with information about exec to the clients.
 	OnExecExit  = "onExecExit"
 	OnExecError = "onExecError"
-
-	BearerTokenHeader = "X-Forwarded-Access-Token"
 )
 
 type MachineIdentifier struct {

--- a/api/rest/activity.go
+++ b/api/rest/activity.go
@@ -1,11 +1,21 @@
 package rest
 
 import (
+	"github.com/eclipse/che-machine-exec/auth"
+	restUtil "github.com/eclipse/che-machine-exec/common/rest"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
 
 func HandleActivityTick(c *gin.Context) {
+	if auth.IsEnabled() {
+		_, err := auth.Authenticate(c)
+		if err != nil {
+			restUtil.WriteErrorResponse(c, err)
+			return
+		}
+	}
+
 	// at this point, it's just stub handler that does nothing
 	// but a bit later ActivityManager will appear and register the latest activity
 	// to post pone workspace stopping by idle timeout

--- a/api/websocket/connect.go
+++ b/api/websocket/connect.go
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2012-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package websocket
+
+import (
+	jsonrpc "github.com/eclipse/che-go-jsonrpc"
+	"github.com/eclipse/che-go-jsonrpc/jsonrpcws"
+	"github.com/eclipse/che-machine-exec/api/events"
+	execRpc "github.com/eclipse/che-machine-exec/api/jsonrpc"
+	"github.com/eclipse/che-machine-exec/api/model"
+	"github.com/eclipse/che-machine-exec/auth"
+	"github.com/eclipse/che-machine-exec/common/rest"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+func HandleConnect(c *gin.Context) {
+	var token string
+	if auth.IsEnabled() {
+		var err error
+		token, err = auth.Authenticate(c)
+		if err != nil {
+			rest.WriteErrorResponse(c, err)
+			return
+		}
+	}
+
+	conn, err := jsonrpcws.Upgrade(c.Writer, c.Request)
+	if err != nil {
+		c.JSON(c.Writer.Status(), err.Error())
+		return
+	}
+
+	logrus.Debug("Create json-rpc channel for new websocket connection")
+	tunnel := jsonrpc.NewManagedTunnel(conn)
+
+	if len(token) > 0 {
+		tunnel.Attributes[execRpc.BearerTokenAttr] = token
+	}
+
+	execConsumer := &events.ExecEventConsumer{Tunnel: tunnel}
+	events.EventBus.SubAny(execConsumer, model.OnExecError, model.OnExecExit)
+
+	tunnel.SayHello()
+}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2012-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package auth
+
+import (
+	"github.com/eclipse/che-machine-exec/cfg"
+	restUtil "github.com/eclipse/che-machine-exec/common/rest"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"net/http"
+)
+
+func IsEnabled() bool {
+	return cfg.UseBearerToken
+}
+
+func Authenticate(c *gin.Context) (string, error) {
+	token, err := extractToken(c)
+	if err != nil {
+		return "", err
+	}
+
+	userID, err := getCurrentUserID(token)
+	if err != nil {
+		logrus.Error("Failed to verify user. Cause: ", err.Error())
+		return "", restUtil.NewError(http.StatusInternalServerError, "unable to verify user with provided token")
+	}
+
+	if userID != cfg.AuthenticatedUserID {
+		return "", restUtil.NewError(http.StatusForbidden, "the current user is not authorized to use API")
+	}
+
+	return token, nil
+}

--- a/auth/token.go
+++ b/auth/token.go
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2012-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package auth
+
+import (
+	restUtil "github.com/eclipse/che-machine-exec/common/rest"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"strings"
+)
+
+const (
+	AccessTokenHeader          = "X-Access-Token"
+	ForwardedAccessTokenHeader = "X-Forwarded-Access-Token"
+)
+
+func extractToken(c *gin.Context) (string, error) {
+	token := c.Request.Header.Get(AccessTokenHeader)
+	if token != "" {
+		logrus.Debug("Access token is found " + token)
+		token = strings.TrimSuffix(token, "Bearer ")
+		return token, nil
+	}
+
+	token = c.Request.Header.Get(ForwardedAccessTokenHeader)
+	if token != "" {
+		logrus.Debug("Forwarded access token is found. " + token)
+		return token, nil
+	}
+
+	return "", restUtil.NewError(http.StatusUnauthorized, "authorization header is missing")
+}

--- a/auth/user.go
+++ b/auth/user.go
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2012-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package auth
+
+import (
+	"errors"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	k8sRest "k8s.io/client-go/rest"
+)
+
+var (
+	UserAPIResource = &metav1.APIResource{
+		Group:    "user.openshift.io",
+		Version:  "v1",
+		Name: "users",
+		Namespaced: false,
+	}
+
+	UserGroupVersion = &schema.GroupVersion{
+		Group:    "user.openshift.io",
+		Version:  "v1",
+	}
+)
+
+func getCurrentUserID(token string) (string, error) {
+	client, err := newDynamicForUsersWithToken(token)
+	if err != nil {
+		return "", err
+	}
+
+	userInfo, err := client.Resource(UserAPIResource, "").Get("~", metav1.GetOptions{})
+	if err != nil {
+		return "", errors.New("Failed to retrieve the current user info. Cause: " + err.Error())
+	}
+
+	logrus.Debugf("Current user info %s, %s", userInfo.GetUID(), userInfo.GetName())
+	return string(userInfo.GetUID()), nil
+}
+
+func newDynamicForUsersWithToken(token string) (dynamic.Interface, error) {
+	config, err := k8sRest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	config.BearerToken = token
+	config.GroupVersion = UserGroupVersion
+	config.APIPath = "apis"
+
+	client, err := dynamic.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -26,7 +26,10 @@ var (
 	// StaticPath path to serve static resources
 	StaticPath string
 	// UseBearerToken - flag to enable/disable using bearer token to avoid users impersonation while accessing to k8s API.
+	// if enabled - authenticated user ID must be configured
 	UseBearerToken bool
+	// AuthenticatedUserID is a user's ID who is authenticated to use API. Is ignored if useBearerToken is disabled
+	AuthenticatedUserID string
 )
 
 func init() {
@@ -54,7 +57,14 @@ func init() {
 			logrus.Errorf("Invalid value '%s' for env variable key '%s'. Value should be boolean", useTokenEnvValue, useTokenEnv)
 		}
 	}
-	flag.BoolVar(&UseBearerToken, "use-bearer-token", defaultUseTokenValue, "to avoid users impersonation while accessing to k8s API.")
+	flag.BoolVar(&UseBearerToken, "use-bearer-token", defaultUseTokenValue, "to avoid users impersonation while accessing to k8s API. When enabled - authenticated user id must be configured")
+
+	defaultAuthenticatedUserID := ""
+	authenticatedUserID, isFound := os.LookupEnv("AUTHENTICATED_USER_ID")
+	if isFound {
+		defaultAuthenticatedUserID = authenticatedUserID
+	}
+	flag.StringVar(&AuthenticatedUserID, "authenticated-user-id", defaultAuthenticatedUserID, "OpenShift user's ID that should has access to API. Is used only if useBearerToken is configured")
 
 	setLogLevel()
 }
@@ -89,4 +99,7 @@ func Print() {
 	logrus.Infof("==> Application url %s", URL)
 	logrus.Infof("==> Absolute path to folder with static resources %s", StaticPath)
 	logrus.Infof("==> Use bearer token: %t", UseBearerToken)
+	if UseBearerToken {
+		logrus.Infof("==> Authenticated user ID: %s", AuthenticatedUserID)
+	}
 }

--- a/client/kubernetes_client_provider.go
+++ b/client/kubernetes_client_provider.go
@@ -14,9 +14,9 @@ package client
 
 import (
 	"errors"
+	"github.com/eclipse/che-machine-exec/auth"
 
 	"github.com/eclipse/che-machine-exec/api/model"
-	"github.com/eclipse/che-machine-exec/cfg"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -94,7 +94,7 @@ func (clientProvider *K8sAPIProvider) getK8sAPIWithBearerToken(token string) (*K
 
 // GetK8sAPI return k8s api object.
 func (clientProvider *K8sAPIProvider) GetK8sAPI(machineExec *model.MachineExec) (*K8sAPI, error) {
-	if cfg.UseBearerToken {
+	if auth.IsEnabled() {
 		logrus.Debug("Create k8s api object with bearer token")
 		return clientProvider.getK8sAPIWithBearerToken(machineExec.BearerToken)
 	}

--- a/common/rest/error.go
+++ b/common/rest/error.go
@@ -12,15 +12,18 @@
 
 package rest
 
-import (
-	"github.com/gin-gonic/gin"
-	"github.com/sirupsen/logrus"
-)
+type HttpError struct {
+	code   int
+	errMsg string
+}
 
-func writeResponse(c *gin.Context, httpStatus int, message string) {
-	c.Writer.WriteHeader(httpStatus)
-	_, err := c.Writer.Write([]byte(message))
-	if err != nil {
-		logrus.Error("Failed to write error response", err)
+func NewError(code int, message string) HttpError {
+	return HttpError{
+		code:   code,
+		errMsg: message,
 	}
+}
+
+func (e HttpError) Error() string {
+	return e.errMsg
 }

--- a/common/rest/response.go
+++ b/common/rest/response.go
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2012-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package rest
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"net/http"
+)
+
+func WriteResponse(c *gin.Context, httpStatus int, message string) {
+	c.Writer.WriteHeader(httpStatus)
+	_, err := c.Writer.Write([]byte(message))
+	if err != nil {
+		logrus.Error("Failed to write error response", err)
+	}
+}
+
+func WriteErrorResponse(c *gin.Context, err error) {
+	if v, ok := err.(HttpError); ok {
+		logrus.Debug("it's http error. Sending " + string(v.code))
+		c.Writer.WriteHeader(v.code)
+	} else {
+		logrus.Debug("it isn't http error. Sending 500")
+		c.Writer.WriteHeader(http.StatusInternalServerError)
+	}
+
+	_, err = c.Writer.Write([]byte(err.Error()))
+	if err != nil {
+		logrus.Error("Failed to write error response", err)
+	}
+}

--- a/vendor/k8s.io/client-go/dynamic/client.go
+++ b/vendor/k8s.io/client-go/dynamic/client.go
@@ -1,0 +1,379 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package dynamic provides a client interface to arbitrary Kubernetes
+// APIs that exposes common high level operations and exposes common
+// metadata.
+package dynamic
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/url"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/conversion/queryparams"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+// Interface is a Kubernetes client that allows you to access metadata
+// and manipulate metadata of a Kubernetes API group.
+type Interface interface {
+	// GetRateLimiter returns the rate limiter for this client.
+	GetRateLimiter() flowcontrol.RateLimiter
+	// Resource returns an API interface to the specified resource for this client's
+	// group and version.  If resource is not a namespaced resource, then namespace
+	// is ignored.  The ResourceInterface inherits the parameter codec of this client.
+	Resource(resource *metav1.APIResource, namespace string) ResourceInterface
+	// ParameterCodec returns a client with the provided parameter codec.
+	ParameterCodec(parameterCodec runtime.ParameterCodec) Interface
+}
+
+// ResourceInterface is an API interface to a specific resource under a
+// dynamic client.
+type ResourceInterface interface {
+	// List returns a list of objects for this resource.
+	List(opts metav1.ListOptions) (runtime.Object, error)
+	// Get gets the resource with the specified name.
+	Get(name string, opts metav1.GetOptions) (*unstructured.Unstructured, error)
+	// Delete deletes the resource with the specified name.
+	Delete(name string, opts *metav1.DeleteOptions) error
+	// DeleteCollection deletes a collection of objects.
+	DeleteCollection(deleteOptions *metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	// Create creates the provided resource.
+	Create(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	// Update updates the provided resource.
+	Update(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	// Watch returns a watch.Interface that watches the resource.
+	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	// Patch patches the provided resource.
+	Patch(name string, pt types.PatchType, data []byte) (*unstructured.Unstructured, error)
+}
+
+// Client is a Kubernetes client that allows you to access metadata
+// and manipulate metadata of a Kubernetes API group, and implements Interface.
+type Client struct {
+	cl             *restclient.RESTClient
+	parameterCodec runtime.ParameterCodec
+}
+
+// NewClient returns a new client based on the passed in config. The
+// codec is ignored, as the dynamic client uses it's own codec.
+func NewClient(conf *restclient.Config) (*Client, error) {
+	// avoid changing the original config
+	confCopy := *conf
+	conf = &confCopy
+
+	contentConfig := ContentConfig()
+	contentConfig.GroupVersion = conf.GroupVersion
+	if conf.NegotiatedSerializer != nil {
+		contentConfig.NegotiatedSerializer = conf.NegotiatedSerializer
+	}
+	conf.ContentConfig = contentConfig
+
+	if conf.APIPath == "" {
+		conf.APIPath = "/api"
+	}
+
+	if len(conf.UserAgent) == 0 {
+		conf.UserAgent = restclient.DefaultKubernetesUserAgent()
+	}
+
+	cl, err := restclient.RESTClientFor(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{cl: cl}, nil
+}
+
+// GetRateLimiter returns rate limier.
+func (c *Client) GetRateLimiter() flowcontrol.RateLimiter {
+	return c.cl.GetRateLimiter()
+}
+
+// Resource returns an API interface to the specified resource for this client's
+// group and version. If resource is not a namespaced resource, then namespace
+// is ignored. The ResourceInterface inherits the parameter codec of c.
+func (c *Client) Resource(resource *metav1.APIResource, namespace string) ResourceInterface {
+	return &ResourceClient{
+		cl:             c.cl,
+		resource:       resource,
+		ns:             namespace,
+		parameterCodec: c.parameterCodec,
+	}
+}
+
+// ParameterCodec returns a client with the provided parameter codec.
+func (c *Client) ParameterCodec(parameterCodec runtime.ParameterCodec) Interface {
+	return &Client{
+		cl:             c.cl,
+		parameterCodec: parameterCodec,
+	}
+}
+
+// ResourceClient is an API interface to a specific resource under a
+// dynamic client, and implements ResourceInterface.
+type ResourceClient struct {
+	cl             *restclient.RESTClient
+	resource       *metav1.APIResource
+	ns             string
+	parameterCodec runtime.ParameterCodec
+}
+
+func (rc *ResourceClient) parseResourceSubresourceName() (string, []string) {
+	var resourceName string
+	var subresourceName []string
+	if strings.Contains(rc.resource.Name, "/") {
+		resourceName = strings.Split(rc.resource.Name, "/")[0]
+		subresourceName = strings.Split(rc.resource.Name, "/")[1:]
+	} else {
+		resourceName = rc.resource.Name
+	}
+
+	return resourceName, subresourceName
+}
+
+// List returns a list of objects for this resource.
+func (rc *ResourceClient) List(opts metav1.ListOptions) (runtime.Object, error) {
+	parameterEncoder := rc.parameterCodec
+	if parameterEncoder == nil {
+		parameterEncoder = defaultParameterEncoder
+	}
+	return rc.cl.Get().
+		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
+		Resource(rc.resource.Name).
+		VersionedParams(&opts, parameterEncoder).
+		Do().
+		Get()
+}
+
+// Get gets the resource with the specified name.
+func (rc *ResourceClient) Get(name string, opts metav1.GetOptions) (*unstructured.Unstructured, error) {
+	parameterEncoder := rc.parameterCodec
+	if parameterEncoder == nil {
+		parameterEncoder = defaultParameterEncoder
+	}
+	result := new(unstructured.Unstructured)
+	resourceName, subresourceName := rc.parseResourceSubresourceName()
+	err := rc.cl.Get().
+		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
+		Resource(resourceName).
+		SubResource(subresourceName...).
+		VersionedParams(&opts, parameterEncoder).
+		Name(name).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// Delete deletes the resource with the specified name.
+func (rc *ResourceClient) Delete(name string, opts *metav1.DeleteOptions) error {
+	return rc.cl.Delete().
+		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
+		Resource(rc.resource.Name).
+		Name(name).
+		Body(opts).
+		Do().
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (rc *ResourceClient) DeleteCollection(deleteOptions *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	parameterEncoder := rc.parameterCodec
+	if parameterEncoder == nil {
+		parameterEncoder = defaultParameterEncoder
+	}
+	return rc.cl.Delete().
+		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
+		Resource(rc.resource.Name).
+		VersionedParams(&listOptions, parameterEncoder).
+		Body(deleteOptions).
+		Do().
+		Error()
+}
+
+// Create creates the provided resource.
+func (rc *ResourceClient) Create(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	result := new(unstructured.Unstructured)
+	resourceName, subresourceName := rc.parseResourceSubresourceName()
+	req := rc.cl.Post().
+		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
+		Resource(resourceName).
+		Body(obj)
+	if len(subresourceName) > 0 {
+		// If the provided resource is a subresource, the POST request should contain
+		// object name. Examples of subresources that support Create operation:
+		//	core/v1/pods/{name}/binding
+		//	core/v1/pods/{name}/eviction
+		//	extensions/v1beta1/deployments/{name}/rollback
+		//	apps/v1beta1/deployments/{name}/rollback
+		// NOTE: Currently our system assumes every subresource object has the same
+		//	 name as the parent resource object. E.g. a pods/binding object having
+		//	 metadada.name "foo" means pod "foo" is being bound. We may need to
+		//	 change this if we break the assumption in the future.
+		req = req.SubResource(subresourceName...).
+			Name(obj.GetName())
+	}
+	err := req.Do().
+		Into(result)
+	return result, err
+}
+
+// Update updates the provided resource.
+func (rc *ResourceClient) Update(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	result := new(unstructured.Unstructured)
+	if len(obj.GetName()) == 0 {
+		return result, errors.New("object missing name")
+	}
+	resourceName, subresourceName := rc.parseResourceSubresourceName()
+	err := rc.cl.Put().
+		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
+		Resource(resourceName).
+		SubResource(subresourceName...).
+		// NOTE: Currently our system assumes every subresource object has the same
+		//	 name as the parent resource object. E.g. a pods/binding object having
+		//	 metadada.name "foo" means pod "foo" is being bound. We may need to
+		//	 change this if we break the assumption in the future.
+		Name(obj.GetName()).
+		Body(obj).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// Watch returns a watch.Interface that watches the resource.
+func (rc *ResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	parameterEncoder := rc.parameterCodec
+	if parameterEncoder == nil {
+		parameterEncoder = defaultParameterEncoder
+	}
+	opts.Watch = true
+	return rc.cl.Get().
+		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
+		Resource(rc.resource.Name).
+		VersionedParams(&opts, parameterEncoder).
+		Watch()
+}
+
+// Patch applies the patch and returns the patched resource.
+func (rc *ResourceClient) Patch(name string, pt types.PatchType, data []byte) (*unstructured.Unstructured, error) {
+	result := new(unstructured.Unstructured)
+	resourceName, subresourceName := rc.parseResourceSubresourceName()
+	err := rc.cl.Patch(pt).
+		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
+		Resource(resourceName).
+		SubResource(subresourceName...).
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// dynamicCodec is a codec that wraps the standard unstructured codec
+// with special handling for Status objects.
+type dynamicCodec struct{}
+
+func (dynamicCodec) Decode(data []byte, gvk *schema.GroupVersionKind, obj runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
+	obj, gvk, err := unstructured.UnstructuredJSONScheme.Decode(data, gvk, obj)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if _, ok := obj.(*metav1.Status); !ok && strings.ToLower(gvk.Kind) == "status" {
+		obj = &metav1.Status{}
+		err := json.Unmarshal(data, obj)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return obj, gvk, nil
+}
+
+func (dynamicCodec) Encode(obj runtime.Object, w io.Writer) error {
+	return unstructured.UnstructuredJSONScheme.Encode(obj, w)
+}
+
+// ContentConfig returns a restclient.ContentConfig for dynamic types.
+func ContentConfig() restclient.ContentConfig {
+	var jsonInfo runtime.SerializerInfo
+	// TODO: scheme.Codecs here should become "pkg/apis/server/scheme" which is the minimal core you need
+	// to talk to a kubernetes server
+	for _, info := range scheme.Codecs.SupportedMediaTypes() {
+		if info.MediaType == runtime.ContentTypeJSON {
+			jsonInfo = info
+			break
+		}
+	}
+
+	jsonInfo.Serializer = dynamicCodec{}
+	jsonInfo.PrettySerializer = nil
+	return restclient.ContentConfig{
+		AcceptContentTypes:   runtime.ContentTypeJSON,
+		ContentType:          runtime.ContentTypeJSON,
+		NegotiatedSerializer: serializer.NegotiatedSerializerWrapper(jsonInfo),
+	}
+}
+
+// paramaterCodec is a codec converts an API object to query
+// parameters without trying to convert to the target version.
+type parameterCodec struct{}
+
+func (parameterCodec) EncodeParameters(obj runtime.Object, to schema.GroupVersion) (url.Values, error) {
+	return queryparams.Convert(obj)
+}
+
+func (parameterCodec) DecodeParameters(parameters url.Values, from schema.GroupVersion, into runtime.Object) error {
+	return errors.New("DecodeParameters not implemented on dynamic parameterCodec")
+}
+
+var defaultParameterEncoder runtime.ParameterCodec = parameterCodec{}
+
+type versionedParameterEncoderWithV1Fallback struct{}
+
+func (versionedParameterEncoderWithV1Fallback) EncodeParameters(obj runtime.Object, to schema.GroupVersion) (url.Values, error) {
+	ret, err := scheme.ParameterCodec.EncodeParameters(obj, to)
+	if err != nil && runtime.IsNotRegisteredError(err) {
+		// fallback to v1
+		return scheme.ParameterCodec.EncodeParameters(obj, v1.SchemeGroupVersion)
+	}
+	return ret, err
+}
+
+func (versionedParameterEncoderWithV1Fallback) DecodeParameters(parameters url.Values, from schema.GroupVersion, into runtime.Object) error {
+	return errors.New("DecodeParameters not implemented on versionedParameterEncoderWithV1Fallback")
+}
+
+// VersionedParameterEncoderWithV1Fallback is useful for encoding query
+// parameters for custom resources. It tries to convert object to the
+// specified version before converting it to query parameters, and falls back to
+// converting to v1 if the object is not registered in the specified version.
+// For the record, currently API server always treats query parameters sent to a
+// custom resource endpoint as v1.
+var VersionedParameterEncoderWithV1Fallback runtime.ParameterCodec = versionedParameterEncoderWithV1Fallback{}

--- a/vendor/k8s.io/client-go/dynamic/client_pool.go
+++ b/vendor/k8s.io/client-go/dynamic/client_pool.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	restclient "k8s.io/client-go/rest"
+)
+
+// ClientPool manages a pool of dynamic clients.
+type ClientPool interface {
+	// ClientForGroupVersionResource returns a client configured for the specified groupVersionResource.
+	// Resource may be empty.
+	ClientForGroupVersionResource(resource schema.GroupVersionResource) (Interface, error)
+	// ClientForGroupVersionKind returns a client configured for the specified groupVersionKind.
+	// Kind may be empty.
+	ClientForGroupVersionKind(kind schema.GroupVersionKind) (Interface, error)
+}
+
+// APIPathResolverFunc knows how to convert a groupVersion to its API path. The Kind field is
+// optional.
+type APIPathResolverFunc func(kind schema.GroupVersionKind) string
+
+// LegacyAPIPathResolverFunc can resolve paths properly with the legacy API.
+func LegacyAPIPathResolverFunc(kind schema.GroupVersionKind) string {
+	if len(kind.Group) == 0 {
+		return "/api"
+	}
+	return "/apis"
+}
+
+// clientPoolImpl implements ClientPool and caches clients for the resource group versions
+// is asked to retrieve. This type is thread safe.
+type clientPoolImpl struct {
+	lock                sync.RWMutex
+	config              *restclient.Config
+	clients             map[schema.GroupVersion]*Client
+	apiPathResolverFunc APIPathResolverFunc
+	mapper              meta.RESTMapper
+}
+
+// NewClientPool returns a ClientPool from the specified config. It reuses clients for the same
+// group version. It is expected this type may be wrapped by specific logic that special cases certain
+// resources or groups.
+func NewClientPool(config *restclient.Config, mapper meta.RESTMapper, apiPathResolverFunc APIPathResolverFunc) ClientPool {
+	confCopy := *config
+
+	return &clientPoolImpl{
+		config:              &confCopy,
+		clients:             map[schema.GroupVersion]*Client{},
+		apiPathResolverFunc: apiPathResolverFunc,
+		mapper:              mapper,
+	}
+}
+
+// Instantiates a new dynamic client pool with the given config.
+func NewDynamicClientPool(cfg *restclient.Config) ClientPool {
+	// restMapper is not needed when using LegacyAPIPathResolverFunc
+	emptyMapper := meta.MultiRESTMapper{}
+	return NewClientPool(cfg, emptyMapper, LegacyAPIPathResolverFunc)
+}
+
+// ClientForGroupVersionResource uses the provided RESTMapper to identify the appropriate resource. Resource may
+// be empty. If no matching kind is found the underlying client for that group is still returned.
+func (c *clientPoolImpl) ClientForGroupVersionResource(resource schema.GroupVersionResource) (Interface, error) {
+	kinds, err := c.mapper.KindsFor(resource)
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return c.ClientForGroupVersionKind(schema.GroupVersionKind{Group: resource.Group, Version: resource.Version})
+		}
+		return nil, err
+	}
+	return c.ClientForGroupVersionKind(kinds[0])
+}
+
+// ClientForGroupVersion returns a client for the specified groupVersion, creates one if none exists. Kind
+// in the GroupVersionKind may be empty.
+func (c *clientPoolImpl) ClientForGroupVersionKind(kind schema.GroupVersionKind) (Interface, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	gv := kind.GroupVersion()
+
+	// do we have a client already configured?
+	if existingClient, found := c.clients[gv]; found {
+		return existingClient, nil
+	}
+
+	// avoid changing the original config
+	confCopy := *c.config
+	conf := &confCopy
+
+	// we need to set the api path based on group version, if no group, default to legacy path
+	conf.APIPath = c.apiPathResolverFunc(kind)
+
+	// we need to make a client
+	conf.GroupVersion = &gv
+
+	dynamicClient, err := NewClient(conf)
+	if err != nil {
+		return nil, err
+	}
+	c.clients[gv] = dynamicClient
+	return dynamicClient, nil
+}

--- a/vendor/k8s.io/client-go/dynamic/dynamic_util.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamic_util.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// VersionInterfaces provides an object converter and metadata
+// accessor appropriate for use with unstructured objects.
+func VersionInterfaces(schema.GroupVersion) (*meta.VersionInterfaces, error) {
+	return &meta.VersionInterfaces{
+		ObjectConvertor:  &unstructured.UnstructuredObjectConverter{},
+		MetadataAccessor: meta.NewAccessor(),
+	}, nil
+}
+
+// NewDiscoveryRESTMapper returns a RESTMapper based on discovery information.
+func NewDiscoveryRESTMapper(resources []*metav1.APIResourceList, versionFunc meta.VersionInterfacesFunc) (*meta.DefaultRESTMapper, error) {
+	rm := meta.NewDefaultRESTMapper(nil, versionFunc)
+	for _, resourceList := range resources {
+		gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, resource := range resourceList.APIResources {
+			gvk := gv.WithKind(resource.Kind)
+			scope := meta.RESTScopeRoot
+			if resource.Namespaced {
+				scope = meta.RESTScopeNamespace
+			}
+			rm.Add(gvk, scope)
+		}
+	}
+	return rm, nil
+}
+
+// ObjectTyper provides an ObjectTyper implementation for
+// unstructured.Unstructured object based on discovery information.
+type ObjectTyper struct {
+	registered map[schema.GroupVersionKind]bool
+}
+
+// NewObjectTyper constructs an ObjectTyper from discovery information.
+func NewObjectTyper(resources []*metav1.APIResourceList) (runtime.ObjectTyper, error) {
+	ot := &ObjectTyper{registered: make(map[schema.GroupVersionKind]bool)}
+	for _, resourceList := range resources {
+		gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, resource := range resourceList.APIResources {
+			ot.registered[gv.WithKind(resource.Kind)] = true
+		}
+	}
+	return ot, nil
+}
+
+// ObjectKinds returns a slice of one element with the
+// group,version,kind of the provided object, or an error if the
+// object is not *unstructured.Unstructured or has no group,version,kind
+// information.
+func (ot *ObjectTyper) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	if _, ok := obj.(*unstructured.Unstructured); !ok {
+		return nil, false, fmt.Errorf("type %T is invalid for determining dynamic object types", obj)
+	}
+	return []schema.GroupVersionKind{obj.GetObjectKind().GroupVersionKind()}, false, nil
+}
+
+// Recognizes returns true if the provided group,version,kind was in
+// the discovery information.
+func (ot *ObjectTyper) Recognizes(gvk schema.GroupVersionKind) bool {
+	return ot.registered[gvk]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -155,6 +155,7 @@ k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v0.0.0-00010101000000-000000000000 => k8s.io/client-go v0.0.0-20180817174322-745ca8300397
 k8s.io/client-go/discovery
+k8s.io/client-go/dynamic
 k8s.io/client-go/kubernetes
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1


### PR DESCRIPTION
Add an ability to configure authenticated user-id.

It's needed in case the use bearer token is configured, so we must make sure that nobody will personalize with already created exec.

I made authenticated-user-id param stick to use-bearer-token although I could imagine that che-machine-exec could be run behind a proxy that already has such check.
But we'll be able to change it later.

It fixes https://github.com/eclipse/che/issues/16489

It depends on https://github.com/che-incubator/che-workspace-operator/pull/77

See how it works for workspace created by developer:
![Screenshot_20200526_105102](https://user-images.githubusercontent.com/5887312/82875121-a8aeb780-9f3f-11ea-9aa3-3ab0cd3a4496.png)
^ right-hand side - kube:admin, left-had side developer
