### PR TITLE
Add /healthz endpoint for monitoring server status.

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,6 +87,10 @@ func main() {
 		rest.HandleActivityTick(c)
 	})
 
+	r.GET("/healthz", func(c *gin.Context) {
+		c.Writer.WriteHeader(http.StatusOK)
+	})
+
 	// create json-rpc routs group
 	appOpRoutes := []jsonrpc.RoutesGroup{
 		jsonRpcApi.RPCRoutes,


### PR DESCRIPTION
Add endpoint /healthz that can be polled to check whether the machine-exec server is up and running.

Helps in checking whether a cloudshell is ready to respond to /exec/init, etc.

Image for testing: `docker.io/amisevsk/che-machine-exec:dev`.

Required for https://github.com/che-incubator/che-workspace-operator/pull/78