### PR TITLE
Support serving data via TLS

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -38,6 +38,9 @@ var (
 	// StopRetryPeriod is a period after which workspace should be tried to stop if the previous try failed
 	// Defaults 10 second
 	StopRetryPeriod time.Duration
+
+	// UseTLS flag to enable/disable serving TLS
+	UseTLS bool
 )
 
 func init() {
@@ -75,8 +78,9 @@ func init() {
 	flag.StringVar(&AuthenticatedUserID, "authenticated-user-id", defaultAuthenticatedUserID, "OpenShift user's ID that should has access to API. Is used only if useBearerToken is configured")
 
 	flag.DurationVar(&IdleTimeout, "idle-timeout", -1*time.Nanosecond, "IdleTimeout is a inactivity period after which workspace should be stopped. Examples: -1, 30s, 15m, 1h")
-
 	flag.DurationVar(&StopRetryPeriod, "stop-retry-period", 10*time.Second, "StopRetryPeriod is a period after which workspace should be tried to stop if the previous try failed. Examples: 30s")
+
+	flag.BoolVar(&UseTLS, "use-tls", false, "Serve content via TLS")
 
 	setLogLevel()
 }

--- a/main.go
+++ b/main.go
@@ -82,7 +82,14 @@ func main() {
 	if activityManager != nil {
 		activityManager.Start()
 	}
-	if err := r.Run(cfg.URL); err != nil {
-		logrus.Fatal("Unable to start server. Cause: ", err.Error())
+
+	if cfg.UseTLS {
+		if err := r.RunTLS(cfg.URL, "/var/serving-cert/tls.crt", "/var/serving-cert/tls.key"); err != nil {
+			logrus.Fatal("Unable to start server with TLS enabled. Cause: ", err.Error())
+		}
+	} else {
+		if err := r.Run(cfg.URL); err != nil {
+			logrus.Fatal("Unable to start server. Cause: ", err.Error())
+		}
 	}
 }


### PR DESCRIPTION
Add flag `--use-tls`, which, if enabled, makes machine-exec serve all content over TLS.

Required for https://github.com/che-incubator/che-workspace-operator/pull/71