### PR TITLE
Added docker buildx support in cico scripts.

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -11,7 +11,7 @@
 #
 # Dockerfile defines che-machine-exec production image eclipse/che-machine-exec-dev
 #
-FROM --platform=$TARGETPLATFORM golang:1.12.8-alpine as go_builder
+FROM golang:1.12.8-alpine as go_builder
 
 ENV USER=machine-exec
 ENV UID=12345
@@ -37,7 +37,7 @@ WORKDIR /che-machine-exec/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -ldflags '-w -s' -a -installsuffix cgo -o /go/bin/che-machine-exec .
 
-FROM --platform=$TARGETPLATFORM node:10.16-alpine as cloud_shell_builder
+FROM node:10.16-alpine as cloud_shell_builder
 COPY --from=go_builder /che-machine-exec/cloud-shell cloud-shell-src
 WORKDIR cloud-shell-src
 RUN yarn && \

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -11,7 +11,7 @@
 #
 # Dockerfile defines che-machine-exec production image eclipse/che-machine-exec-dev
 #
-FROM golang:1.12.8-alpine as go_builder
+FROM --platform=$TARGETPLATFORM golang:1.12.8-alpine as go_builder
 
 ENV USER=machine-exec
 ENV UID=12345
@@ -37,7 +37,7 @@ WORKDIR /che-machine-exec/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -ldflags '-w -s' -a -installsuffix cgo -o /go/bin/che-machine-exec .
 
-FROM node:10.16-alpine as cloud_shell_builder
+FROM --platform=$TARGETPLATFORM node:10.16-alpine as cloud_shell_builder
 COPY --from=go_builder /che-machine-exec/cloud-shell cloud-shell-src
 WORKDIR cloud-shell-src
 RUN yarn && \

--- a/cico_build_ci.sh
+++ b/cico_build_ci.sh
@@ -22,4 +22,5 @@ export SCRIPT_DIR
 
 load_jenkins_vars
 install_deps
+check_buildx_support
 build_and_push

--- a/cico_build_nightly.sh
+++ b/cico_build_nightly.sh
@@ -22,5 +22,6 @@ export SCRIPT_DIR
 
 load_jenkins_vars
 install_deps
+check_buildx_support
 set_nightly_tag
 build_and_push

--- a/cico_build_release.sh
+++ b/cico_build_release.sh
@@ -22,5 +22,6 @@ export SCRIPT_DIR
 
 load_jenkins_vars
 install_deps
+check_buildx_support
 set_release_tag
 build_and_push

--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -33,6 +33,27 @@ function load_jenkins_vars() {
   fi
 }
 
+function check_buildx_support() {
+  export DOCKER_BUILD_KIT=1
+  export DOCKER_CLI_EXPERIMENTAL=enabled
+
+  docker_version="$(docker --version | cut -d' ' -f3 | tr -cd '0-9.')"
+  if [[ $docker_version < 19.03 ]]; then
+    echo "CICO: Docker $docker_version greater than or equal to 19.03 is required."
+    exit 1
+  fi
+
+  # Kernel
+  kernel_version="$(uname -r)"
+  if [[ "$(version "$kernel_version")" < "$(version '4.8')" ]]; then
+    echo "Kernel $kernel_version too old - need >= 4.8." \
+          " Install a newer kernel."
+  else
+    echo "kernel $kernel_version has binfmt_misc fix-binary (F) support."
+  fi
+
+}
+
 function install_deps() {
   # We need to disable selinux for now, XXX
   /usr/sbin/setenforce 0  || true
@@ -44,7 +65,16 @@ function install_deps() {
     git
 
   service docker start
+  
+  #Enable qemu and binfmt support
+  docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
+  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  
   echo 'CICO: Dependencies installed'
+}
+
+function version() {
+  printf '%02d' $(echo "$1" | tr . ' ' | sed -e 's/ 0*/ /g') 2>/dev/null
 }
 
 function set_release_tag() {
@@ -66,12 +96,6 @@ function set_git_commit_tag() {
   export GIT_COMMIT_TAG
 }
 
-function tag_push() {
-  local TARGET=$1
-  docker tag "${IMAGE}" "$TARGET"
-  docker push "$TARGET" | cat
-}
-
 function build_and_push() {
   REGISTRY="quay.io"
   DOCKERFILE="Dockerfile"
@@ -86,13 +110,16 @@ function build_and_push() {
 
   # Let's build and push image to 'quay.io' using git commit hash as tag first
   set_git_commit_tag
-  docker build -t ${IMAGE} -f ./build/dockerfiles/${DOCKERFILE} . | cat
-  tag_push "${REGISTRY}/${ORGANIZATION}/${IMAGE}:${GIT_COMMIT_TAG}"
-  echo "CICO: '${GIT_COMMIT_TAG}' version of images pushed to '${REGISTRY}/${ORGANIZATION}' organization"
 
-  # If additional tag is set (e.g. "nightly"), let's tag the image accordingly and also push to 'quay.io'
+  # Create a new builder instance using buildx 
+  docker buildx create --use --name builder
+  docker buildx inspect --bootstrap
+  docker buildx build --platform linux/amd64,linux/s390x -t ${REGISTRY}/${ORGANIZATION}/${IMAGE}:${GIT_COMMIT_TAG} -f ./build/dockerfiles/${DOCKERFILE} --push --progress plain --no-cache .
+  echo "CICO: '${GIT_COMMIT_TAG}' version of images pushed to '${REGISTRY}/${ORGANIZATION}' organization"
+  
+  # If additional tag is set (e.g. "nightly"), let's build the image accordingly and also push to 'quay.io'
   if [ -n "${TAG}" ]; then
-    tag_push "${REGISTRY}/${ORGANIZATION}/${IMAGE}:${TAG}"
+    docker buildx build --platform linux/amd64,linux/s390x -t ${REGISTRY}/${ORGANIZATION}/${IMAGE}:${TAG} -f ./build/dockerfiles/${DOCKERFILE} --push --progress plain --no-cache .
     echo "CICO: '${TAG}'  version of images pushed to '${REGISTRY}/${ORGANIZATION}' organization"
   fi
 }

--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -34,12 +34,9 @@ function load_jenkins_vars() {
 }
 
 function check_buildx_support() {
-  export DOCKER_BUILD_KIT=1
-  export DOCKER_CLI_EXPERIMENTAL=enabled
-
   docker_version="$(docker --version | cut -d' ' -f3 | tr -cd '0-9.')"
-  if [[ $docker_version < 19.03 ]]; then
-    echo "CICO: Docker $docker_version greater than or equal to 19.03 is required."
+  if [[ "$(version "$docker_version")" < "$(version '19.03')" ]]; then
+    echo "CICO: Docker $docker_version is too old. Greater than or equal to 19.03 is required."
     exit 1
   fi
 
@@ -66,6 +63,10 @@ function install_deps() {
 
   service docker start
   
+  #set buildx env
+  export DOCKER_BUILD_KIT=1
+  export DOCKER_CLI_EXPERIMENTAL=enabled
+
   #Enable qemu and binfmt support
   docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -75,7 +75,7 @@ function install_deps() {
 
   #Enable qemu and binfmt support
   docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
-  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  docker run --rm --privileged multiarch/qemu-user-static:4.2.0-7 --reset -p yes
   
   echo 'CICO: Dependencies installed'
 }


### PR DESCRIPTION
Signed-off-by: Prabhav Thali <Prabhav.Thali1@ibm.com>

**What does this PR do?**
Adds docker buildx support in cico scripts to build multi-arch images.

**What issues does this PR fix or reference?**
This refers to [#17124](https://github.com/eclipse/che/issues/17124)