### PR TITLE
Update base build image from rhel8/go-toolset:1.13.4-22 to rhel8/go-toolset:1.13.4-27

### DIFF
--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/rhel8/go-toolset
-FROM registry.redhat.io/rhel8/go-toolset:1.13.4-22 as builder
+FROM registry.redhat.io/rhel8/go-toolset:1.13.4-27 as builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /che-machine-exec/


### PR DESCRIPTION
Updates base build image from rhel8/go-toolset:1.13.4-22 to rhel8/go-toolset:1.13.4-27

It's generated automatically with `../codeready-workspaces/product/updateBaseImages.sh -b updateRHELBaseImage -w ./build/dockerfiles -f rhel.Dockerfile`