### PR TITLE
Migrate nightly jobs from ci centos to GH actions

### DIFF
--- a/.github/workflows/gh_actions_pr.yaml
+++ b/.github/workflows/gh_actions_pr.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2012-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+name: Docker Build
+
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout che-machine-exec source code
+      uses: actions/checkout@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Build and push nightly
+      uses: docker/build-push-action@v2
+      with:
+        file: build/dockerfiles/Dockerfile
+        platforms: linux/amd64,linux/ppc64le,linux/s390x
+        push: false
+        tags: quay.io/eclipse/che-machine-exec:nightly

--- a/.github/workflows/gh_actions_pr.yaml
+++ b/.github/workflows/gh_actions_pr.yaml
@@ -28,4 +28,4 @@ jobs:
         file: build/dockerfiles/Dockerfile
         platforms: linux/amd64,linux/ppc64le,linux/s390x
         push: false
-        tags: quay.io/eclipse/che-machine-exec:nightly
+        tags: quay.io/eclipse/che-machine-exec:pr-check

--- a/.github/workflows/gh_actions_pr.yaml
+++ b/.github/workflows/gh_actions_pr.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2012-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/gh_actions_push.yaml
+++ b/.github/workflows/gh_actions_push.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2012-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+name: Nightly Dockerimage Build
+
+on:
+  push:
+    branches: [ master ]
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout che-machine-exec source code
+      uses: actions/checkout@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to quay.io
+      uses: docker/login-action@v1 
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        registry: quay.io
+    - name: Build and push nightly
+      uses: docker/build-push-action@v2
+      with:
+        file: build/dockerfiles/Dockerfile
+        platforms: linux/amd64,linux/ppc64le,linux/s390x
+        push: true
+        tags: quay.io/eclipse/che-machine-exec:nightly

--- a/.github/workflows/gh_actions_push.yaml
+++ b/.github/workflows/gh_actions_push.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2012-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/gh_actions_push.yaml
+++ b/.github/workflows/gh_actions_push.yaml
@@ -12,8 +12,8 @@
 name: Nightly Dockerimage Build
 
 on:
-  push:
-    branches: [ master ]
+  schedule:
+    - cron:  '0 0 * * *'
 jobs:
   build-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Refference issue: https://github.com/eclipse/che/issues/17875
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>