### PR TITLE
Add stopped-by annotation for adding the reason why a DevWorkspace was stopped

### DIFF
--- a/activity/manager.go
+++ b/activity/manager.go
@@ -144,6 +144,11 @@ func (m managerImpl) stopWorkspace() error {
 
 	stopWorkspacePath := &unstructured.Unstructured{
 		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"controller.devfile.io/stopped-by": "inactivity",
+				},
+			},
 			"spec": map[string]interface{}{
 				"started": false,
 			},


### PR DESCRIPTION
This PR updates the activity manager to add the reason why a DevWorkspace was stopped.

Related PR: https://github.com/devfile/devworkspace-operator/pull/190

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>